### PR TITLE
Update partner account routes

### DIFF
--- a/app/api/(v1)/(protected)/partners/account/route.ts
+++ b/app/api/(v1)/(protected)/partners/account/route.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 const schema = z.object({
   partner_id: z.number(),
+  entity_id: z.number(),
   bank_account: z.string().length(29),
   mfo: z.string().optional(),
   bank_name: z.string().optional(),
@@ -22,9 +23,26 @@ const handler = async (_req: NextRequest, body: Body) => {
       partner_id: body.partner_id,
       bank_account: body.bank_account,
     },
+    include: {
+      entities: true,
+    },
   });
 
   if (existing) {
+    const alreadyLinked = existing.entities.some(
+      (e) => e.entity_id === body.entity_id
+    );
+
+    if (!alreadyLinked) {
+      await prisma.partner_account_numbers_on_entities.create({
+        data: {
+          entity_id: body.entity_id,
+          partner_account_number_id: existing.id,
+          is_default: body.is_default ?? false,
+        },
+      });
+    }
+
     return NextResponse.json({
       success: true,
       created: existing,
@@ -38,6 +56,13 @@ const handler = async (_req: NextRequest, body: Body) => {
       bank_account: body.bank_account,
       mfo: body.mfo,
       bank_name: body.bank_name,
+    },
+  });
+
+  await prisma.partner_account_numbers_on_entities.create({
+    data: {
+      entity_id: body.entity_id,
+      partner_account_number_id: created.id,
       is_default: body.is_default ?? false,
     },
   });


### PR DESCRIPTION
## Summary
- require entity_id when creating partner account
- link new or existing account with entity
- update default flag through partner_account_numbers_on_entities

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_684306a5c9e88328a990e8fc98e789e9